### PR TITLE
Fix header and footer formatting

### DIFF
--- a/lisp/ido-select-window.el
+++ b/lisp/ido-select-window.el
@@ -1,4 +1,4 @@
-;;; ido-select-window --- Select a window using ido and buffer names.
+;;; ido-select-window.el --- Select a window using ido and buffer names -*- lexical-binding: t -*-
 ;;
 ;; Copyright (C) 2013 Peter Jones <pjones@devalot.com>
 ;;
@@ -40,10 +40,6 @@
 ;;
 ;;; Code:
 
-;; Local Variables:
-;; lexical-binding: t
-;; End:
-
 (defgroup ido-select-window nil
   "A simple package to switch windows using ido."
   :version "0.1.0"
@@ -77,4 +73,4 @@ selected window is excluded from the list of windows."
       (call-interactively 'other-window))))
 
 (provide 'ido-select-window)
-;;; ido-select-window ends here
+;;; ido-select-window.el ends here


### PR DESCRIPTION
- .el is required for package-buffer-info to parse the file correctly
- lexical-binding must be set on the first line, according to warnings issued in Emacs HEAD

(Background: I'm adding this to [MELPA](http://melpa.milkbox.net/))
